### PR TITLE
Remove non existent js files

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -4,8 +4,6 @@ script('timetracker', "moment.min");
 script('timetracker', "daterangepicker.min");
 script('timetracker', "tabulator");
 script('timetracker', "Chart.min");
-script('timetracker', "jspdf.min");
-script('timetracker', "jspdf.plugin.autotable.min");
 //script('timetracker', "select2");
 style('timetracker', "kingtable");
 style('timetracker', "daterangepicker");


### PR DESCRIPTION
Those files don't exist inside the js directory and lead to those errors in Nextcloud 18:
```
Refused to execute script from 'https://nextcloud.example.de/apps/files/' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.
```

The url of one of the requested files is ``https://nextcloud.example.de/custom_apps/timetracker/js/jspdf.min.js?v=81776198-5`` and cause it is non existing nextcloud redirects to ``/app/files``.