### PR TITLE
Reduce minute selection to 15 min increments

### DIFF
--- a/js/src/timer.js
+++ b/js/src/timer.js
@@ -100,6 +100,7 @@ function() {
           var picker = $("#hours-manual-entry").daterangepicker({
             timePicker: true,
             timePicker24Hour: true,
+            timePickerIncrement: 15,
             locale: {
                 format: dtf.dtformat(),
                 firstDay: firstDay


### PR DESCRIPTION
Manual entry of work items has minutes in 15 minute increments
to simplify entry dialog.

Edit dialog still lets you select by the minute.